### PR TITLE
Major overhaul of contribution issue templates to reflect new processes & governance

### DIFF
--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -34,10 +34,11 @@ As a project onboarding into FINOS, you should familiarize yourself and your con
 
 This section contains information to be provided by the contributor to give it the best chances to be approve stage. They largely mirror the requirements described in the [incubation checklist](/docs/governance/software-projects/stages/incubating/#incubating-lifecycle-checklist). Please fill below as appropriate:
 
-### Proposed Project Name
-`enter here top three preferred options`
+### Proposed Project Metadata
+- Name: `enter here proposed project name`
+- Slug: `enter here proposed project description`
 
-> While, in case of project acceptance, a trademark search will be perfomed, it's recommended for the project team to provide at least 3 options which don't obviously clash with existing trademarks or open source project names
+> Please review the [trademark checks](docs/governance/Software-Projects/contribution#trademark) that will be performed on the projects.
 
 ### Business Problem
 > Describe the business or technical problem the contribution solves and for whom
@@ -66,6 +67,7 @@ This section contains information to be provided by the contributor to give it t
  - [ ] Does the project have a registered trademark or the name has been prevously used in the public domain?
    - If so, add link to previously used public links : `link to press release / repository / blog`
  - [ ] Is there an existing logo?
+   - If so, please add link or attach to the issue: `link to high res logo or added as attachment`
  - [ ] Is there a high-level pitch deck to be evaluated by Technical Oversight Committee?
    - If so, please add link or attach to the issue: `link to a ~15 mins slide deck or added as attachment`
  - [ ] Are meetings currently held for the project?
@@ -132,7 +134,7 @@ The [FINOS Technical Oversight Committee](https://github.com/finos/technical-ove
 Once you are happy with the socialization phase (garnered enough support / interest, addressed open questions, etc), please check the box below and put a comment on this issue so it can be sent to the TOC for approval. 
 
 - [ ] I am happy for this issue to be sent to the Technical Oversight Committee for formal review and approval
-- [ ] FINOS team added this to FINOS TOC for review
+- [ ] FINOS team added this to FINOS TOC Backlog and assigned TOC Chair for review
 
 ### TOC Approval findings 
 - [ ] FINOS TOC reviewed the contribution and the contribution was: `accepted|rejected`
@@ -143,12 +145,16 @@ Once you are happy with the socialization phase (garnered enough support / inter
 Before the FINOS team can onboard your project, there are a few housekeeping items that need to be taken care of from an IP and infastructure standpoint. These must be completed by the contributor, with help if required from the FINOS Infrastructure team, so please familiarize yourself with the [requirements](/docs/governance/software-projects/contribution/#step-4-ip-review--transfer-of-contributions).
 
 ### Steps
-- [ ] FINOS team confirmed project brand and logo, if existing, are usable in the public domain. This might require completion of [project contribution agreement](https://community.finos.org/governance-docs/The.Linux.Foundation.--.Form.of.Trademark.Assignment.20221202.pdf) to properly assign trademarks or identify a new project name and logo.
+- [ ] Usable name and logo identified
+  - [ ] FINOS team confirmed project brand and logo are usable in the public domain. This might require completion of [project contribution agreement](https://community.finos.org/governance-docs/The.Linux.Foundation.--.Form.of.Trademark.Assignment.20221202.pdf) to properly assign trademarks.
+  - [ ] Failed the above, new project name and logo is being identified
+- [ ] FINOS team enables [EasyCLA](https://easycla.lfx.linuxfoundation.org/#/) with FINOS CLA
 - [ ] FINOS contributor license agreement is reviewed and executed by all maintainers
-- [ ] FINOS team was give admin access to any existing project account (e.g. GitHub, domain names, social media) to be able to act on behalf of the contributor for accounts related to the project  
+- [ ] FINOS team was given admin access to any existing project account (e.g. GitHub, domain names, social media) to be able to act on behalf of the contributor for accounts related to the project  
 - [ ] Kick-off meeting organized by FINOS team, including:
    - [ ] Review contribution checklist with FINOS staff
-   - [ ] Review FINOS project blueprint
+   - [ ] Contributor reviewed [FINOS software project blueprint](https://github.com/finos/software-project-blueprint/blob/main/CONTRIBUTING.md) and agreed to adopt governance
+   - [ ] FINOS agrees with maintainers on category and sub-category (for [FINOS Landscape](https://landscape.finos.org/))
 
 ## 4.  Transfer and onboarding in FINOS
 
@@ -160,14 +166,13 @@ This is performed by FINOS Infra once the three previous stages are complete, wi
 ## Code Transfer Meeting
 - [ ] Transfer all code assets as GitHub repositories under github.com/finos
 - [ ] Rename main branch to `main` (instead of `master`)
-- [ ] Enable EasyCLA
 - [ ] Check that CVE (and preferably static code analysis, if applicable) scanning is in place
 - [ ] Enable [branch protection](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) (`Require a pull request before merging`)
 - [ ] Enable automated dependency update, using [Renovate](https://renovatebot.com/)
-- [ ] (best effort) Update release coordinates and code namespace to include `finos`
+- [ ] (best effort or to be completed right after onboarding) Update release coordinates and code namespace to include `finos`
 
 # 5. Announcement 
 - [ ] Issue assigned to FINOS DevRel team
 - [ ] Mantainer team agreed with FINOS DevRel team on announcements sequencing: `add link to internal task`
-- [ ] Technical announcement was sent to announce@finos.org (see [template](https://community.finos.org/docs/governance/Software-Projects/contribution#step-5-contribution-announcements): `add link to announce@ archive` 
-- [ ] If applicable, project was announced on FINOS marketing channels: `add link to FINOS social / press release`
+  - [ ] Technical announcement was sent to announce@finos.org (see [template](https://community.finos.org/docs/governance/Software-Projects/contribution#step-5-contribution-announcements): `add link to announce@ archive` 
+  - [ ] If applicable, project was announced on FINOS marketing channels: `add link to FINOS social / press release`

--- a/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Software-Project-Contribution.md
@@ -1,65 +1,84 @@
 ---
 name: "\U0001F58ASoftware Project Contribution and Onboarding"
 about: To Contribute a Software Project to FINOS
-title: Software Project Contribution and Onboarding
+title: "[insert name here] Software Project Contribution and Onboarding"
 labels: contribution
+assignees: maoo, TheJuanAndOnly99
+---
 
 ---
-Please note that only FINOS members can propose new projects. If you're interested in membership, see https://www.finos.org/membership-benefits#become-a-member.
+# Prerequisites
 
+## Membership requirement to contribute new projects
 
-# Onboarding Process
+Please note that only FINOS members can propose new projects. If you're interested in membership, see [here](https://www.finos.org/membership-benefits#become-a-member). You can still submit this contribution if your organization is not a [FINOS member](https://finos.org/members), but you will be required to have a maintainer from a FINOS member.
 
-Completing an onboarding of a project into FINOS requires following these 5 main steps:  
+- [ ] I confirm I am contributing on behalf of a FINOS member (`add FINOS member organization name`) or I will seek a maintainer from a FINOS member during socialization 
 
-1.  [**Describing the Contribution**](#1-describing-the-contribution) _led by contributor_
-2.  [**Approval**](#2-approval) _led by FINOS TOC_
-3.  [**Preparing for Onboarding**](#3-preparing-for-onboarding) _led by contributor_
-4.  [**Onboarding**](#4--finos-onboarding) _completed by FINOS Infra_
-5.  [**Announcement**](#4--finos-onboarding) _led by FINOS Marketing_
+## Understading the contribution Process
 
-# 1. Describing The Contribution
+Completing an onboarding of a project into FINOS comprises following 5 main steps described in details in our [Community Repository](https://community.finos.org/docs/governance/Software-Projects/contribution#contribution-of-an-existing-code-base-into-finos-as-a-new-project). 
 
-This is a list of questions that need to be answered by the contributor in order to allow a new project to pass to the approval stage of onboarding.
+ - [ ] I confirm I have reviewed the contribution process.
 
-## Business Problem
-*Describe the business problem the contribution solves*
+## Understanding FINOS
+
+As a project onboarding into FINOS, you should familiarize yourself and your contributor team with the following FINOS information: [FINOS overview](https://www.finos.org/hubfs/An%20Introduction%20to%20FINOS.pdf), [FINOS Software Projects Governance](/docs/governance/#open-source-software-projects), [FINOS Project Lifecycle](/docs/governance/Software-Projects/project-lifecycle), [FINOS Maintainers cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet/).
+
+- [ ] I confirm I am familiar with the FINOS governance and maintainers responsibilities
+
+---
+# Contribution information
+
+## Describing The Contribution
+
+This section contains information to be provided by the contributor to give it the best chances to be approve stage. They largely mirror the requirements described in the [incubation checklist](/docs/governance/software-projects/stages/incubating/#incubating-lifecycle-checklist). Please fill below as appropriate:
+
+### Proposed Project Name
+`enter here top three preferred options`
+
+> While, in case of project acceptance, a trademark search will be perfomed, it's recommended for the project team to provide at least 3 options which don't obviously clash with existing trademarks or open source project names
+
+### Business Problem
+> Describe the business or technical problem the contribution solves and for whom
  
-## Proposed Solution
-*Describe the type of contribution (project or working group) and how it solves that business problem*
+### Proposed Solution
+> Describe how this software project solves that business problem
 
-## Tentative Roadmap
-*Describe the short and medium term goals and phases of the project. What does success look like for this project?* 
+### Tentative Roadmap
+> Describe the short and medium term goals and phases of the project. What does success look like for this project?
  
-## Current State
-*Summarize the history and current state of the project*
+### Current State
+> Summarize the history and current state of the project
  
-## Existing Materials
-*If materials already exist, provide a link to them that Foundation staff can access - if it's in a private GitHub.com repositories, you should invite the finos-admin user with R/O permissions to those repositories*
-
-## Identify project meta
- - [ ] GitHub / GitLab Repository _(delete as appropriate)_
-   - [ ] URL for the repository _(if it exists)_
-   - [ ] Project Name _(enter here)_
-   - [ ] @finos-admin has been given read-only permissions if private
- - [ ] Is Continuous Integration used? _If so, which system is used?_
- - [ ] Was the project ever released? _(yes / no)_ 
-   - [ ] If so, are releases public? _(yes / no)_ 
-   - [ ] And what's the latest released version?
- - [ ] Existing Project Documentation _( URL / microsite / PDF etc detail here)_
- - [ ] Does the name have a registered trademark? _(yes / no)_
- - [ ] Is there a logo? _(yes / no)_
- - [ ] High-Level Presentation prepared for Technical Oversight Committee _(~15 mins)_
- - [ ] Are meetings currently held for the project? _(yes / no + details)_
- - [ ] Are meeting minutes, agenda and attendance tracked? _(yes / no + details)_
- - [ ] Is it a data model? Interested in [FINOS Legend Studio Sandbox](https://www.finos.org/legend)?
+### Identify existing project resources and materials
+ - [ ] Does the project have a public Source Repository?
+   - If so, what's the URL for the repository: `replace if it exists or add N/A`
+   - [ ] If code is private, was @finos-admin already given read-only permissions to the repo or a code provided to the team?
+ - [ ] Is Continuous Integration used?
+   - If so, which CI/CD system is used: `enter here`
+ - [ ] Was the project ever had public releases? 
+   - If so, where's the latest released version: `add link here`
+ - [ ] Does the project build work successfully?
+   - If so, please add link to build instructions: `add link to build instructions`
+ - [ ] Does the project have existing documentation?
+   - If so, provide more information: `add site URL / PDF / etc here`
+ - [ ] Does the project have a registered trademark or the name has been prevously used in the public domain?
+   - If so, add link to previously used public links : `link to press release / repository / blog`
+ - [ ] Is there an existing logo?
+ - [ ] Is there a high-level pitch deck to be evaluated by Technical Oversight Committee?
+   - If so, please add link or attach to the issue: `link to a ~15 mins slide deck or added as attachment`
+ - [ ] Are meetings currently held for the project?
+   - If so, please add link to current meeting schedule / minutes: `link to meeting details`
+ - [ ] Is it a data model?
+   - [ ] If so, are you interested in modeling it in the [FINOS Legend Studio Sandbox](https://www.finos.org/legend)?
 
 ## Development Team
 
 ### Maintainers
-*Who will be the [project maintainer(s)](https://community.finos.org/docs/finos-maintainers-cheatsheet/#maintainer-responsibilities-and-available-resources)? Provide full name, affiliation, work email address, and GitHub / GitLab username.*
+*Who will be the Project Maintainers who are responsible for maintaining the project and engaging with the community per [maintainer's responsibilities](https://community.finos.org/docs/finos-maintainers-cheatsheet/#maintainer-responsibilities-and-available-resources)? Provide full name, affiliation, GitHub / GitLab username and email address where available*
 
-|Name                        |Affiliation              |Work Email Address             |Github / GitLab username              |
+|Name                        |Affiliation              | Email Address             |Github / GitLab username              |
 |----------------------------|-------------------------|-------------------------------|--------------------------------------|
 |John Example                |Example LTD              |john@example.com               |@johnexampleabc                       |
 |Jane Example                |Example LTD              |jane@example.com               |@janeexamplexyz                       |
@@ -75,78 +94,68 @@ This is a list of questions that need to be answered by the contributor in order
 
 
 ### Target Contributors
-*Describe the contributor profile (background, position, organization) you would like to get contributions from.*
+*Describe the contributor profile (background, position, etc) and if applicable organizational profile (financial institutions, tech vendors, consulting firms, etc) you would like to get contributions from*
 
-## Project Communication Channel(s)
+## Preferred project infrastructure
+If the project is approved, FINOS will provision the infrastructure necessary for [development, release and project collaboration](https://community.finos.org/docs/collaboration-infrastructure). Below a list of questions which will help us accelerate the onboarding process and tailor it to the maintainers needs:
 
-- [ ] Contributor to ask maintainers which communications channels they'd like to use:
-- Asynchronous
-  - [ ] GitHub Issues _(public)_
-  - [ ] GitHub Discussions _(public)_
+- Which code hosting platform does the project prefer? *[Github](https://github.com/finos/)|[GitLab](https://gitlab.com/finos)* 
+- Please check below which asynchronous collaboration channels will the project like to use?
+  - [ ] GitHub Issues
+  - [ ] GitHub Public Discussions
   - [ ] GitHub Team Discussions _(consisting of the above described contributors)_
-    - [ ] Public
-    - [ ] Private
-  - [ ] Mailing-list (groups.io)
-  - [ ] FINOS Slack Channel (consisting of the above described contributors)
-    - [ ] General (public) _(supply channel name)_ 
-    - [ ] Leadership (private) _(supply channel name)_
+    - Public (Mandatory) _(consisting of the above described contributors)_
+    - [ ] Private (Optional)
+  - [ ] Mailing-list (lists.finos.org)
+    - General (Mandatory, for project community): `add preferred address, XXXX-general@lists.finos.org`
+    - [ ] Private (Optional)
+  - [ ] FINOS Slack Channel _(consisting of the above described contributors)_
+    - General Project Community Public channel (mandatory): `add preferred channel name, e.g. #projectName-general`
+    - [ ] Maintainers Private Channel (Optional) `add preferred channel name, e.g. #projectName-maintainers`
 - Synchronous
-  - [ ] Recurring meetings
+  - [ ] Will the project host recurring meetings complying with the [FINOS meeting procedures](https://community.finos.org/docs/governance/meeting-procedures)?
 
-## Understanding FINOS Onboarding Requirements
+---
+# Next steps and what to expect 
 
-As a project onboarding into FINOS, you will need to familiarize yourself and your contributor team with the following materials:
+## 1. Socialisation 
+It's highly recommended that once you submit this issue, you or anyone in the maintainer team proceed with socializing directly to the [FINOS community](mailto:community@finos.org) and through your personal network. The goal is to generate interest, support and ideally additional committed maintainers expressing the interest on the issue before it's sent to the Technical Oversight Committee for approval. 
 
- - [FINOS overview](https://www.finos.org/hubfs/An%20Introduction%20to%20FINOS.pdf) (if necessary)
- - [FINOS Maintainers cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet/)
- - [FINOS Project/Standards Governance](https://community.finos.org/docs/governance)
- - [FINOS Project Lifecycle](https://community.finos.org/docs/governance/Software-Projects/project-lifecycle)
+Instructions and a template for you to adjust are avaialble in the [Contribution Process Socialization](https://community.finos.org/docs/governance/software-projects/contribution/#step-2-socialization) documentation.
 
-## Socialisation 
-- [ ] Write and send contribution proposal announcement (optional - see below)
-- [ ] Lead maintainer to send out announcement to community@finos.org using this template:
+- [ ] I confirm I have socialized this contribution to `community@finos.org` (to be checked after the issue is raised)
     
-    ```
-    Dear FINOS Community, 
-    
-    We would like to propose a new FINOS project. Please review the proposal details at (_TODO: add link to the GitHub issue proposal_).
-    
-    If you're interested in participating, please :+1: the GitHub issue proposal and drop a comment with your name, org and email
+## 2. Approval
 
-   Thanks a lot,
-   ```     
+The [FINOS Technical Oversight Committee](https://github.com/finos/technical-oversight-committee) (TOC) is responsible for approving FINOS project contributions into Incubating stage according to the [contribution principles](https://github.com/finos/technical-oversight-committee/blob/master/contribution-principles.md) and the [incubation checklist](/docs/governance/software-projects/stages/incubating/#incubating-lifecycle-checklist).
 
-# 2. Approval
+Once you are happy with the socialization phase (garnered enough support / interest, addressed open questions, etc), please check the box below and put a comment on this issue so it can be sent to the TOC for approval. 
 
-The [FINOS Technical Oversight Committee](https://github.com/finos/technical-oversight-committee) (TOC) is responsible for approving FINOS project contributions; feel free to check their [contribution principles](https://github.com/finos/technical-oversight-committee/blob/master/contribution-principles.md).
+- [ ] I am happy for this issue to be sent to the Technical Oversight Committee for formal review and approval
+- [ ] FINOS team added this to FINOS TOC for review
 
-If needed, the TOC will request a follow up either via GitHub Issue comments or by inviting project leads to one of their recurrent meetings.
+### TOC Approval findings 
+- [ ] FINOS TOC reviewed the contribution and the contribution was: `accepted|rejected`
 
-Tasks (for FINOS Infra/TOC)
-- [ ] TOC to invite contributors to present their project
-- [ ] FINOS TOC approves/rejects the contribution
+> TOC to enter high level findings summary here supporting the decision
 
-## TOC Findings / Report
-*TOC to enter findings summary here.*
+## 3. Preparing For Onboarding
+Before the FINOS team can onboard your project, there are a few housekeeping items that need to be taken care of from an IP and infastructure standpoint. These must be completed by the contributor, with help if required from the FINOS Infrastructure team, so please familiarize yourself with the [requirements](/docs/governance/software-projects/contribution/#step-4-ip-review--transfer-of-contributions).
 
-# 3. Preparing For Onboarding
+### Steps
+- [ ] FINOS team confirmed project brand and logo, if existing, are usable in the public domain. This might require completion of [project contribution agreement](https://community.finos.org/governance-docs/The.Linux.Foundation.--.Form.of.Trademark.Assignment.20221202.pdf) to properly assign trademarks or identify a new project name and logo.
+- [ ] FINOS contributor license agreement is reviewed and executed by all maintainers
+- [ ] FINOS team was give admin access to any existing project account (e.g. GitHub, domain names, social media) to be able to act on behalf of the contributor for accounts related to the project  
+- [ ] Kick-off meeting organized by FINOS team, including:
+   - [ ] Review contribution checklist with FINOS staff
+   - [ ] Review FINOS project blueprint
 
-Before the FINOS team can onboard your project, there are a few housekeeping items that need to be taken care of.  These must be completed by the contributor, with help if required from the FINOS Infra.   
-
-## Kick-off meeting
-- [ ] Review the [project contribution agreement](https://community.finos.org/governance-docs/The.Linux.Foundation.--.Form.of.Trademark.Assignment.20221202.pdf) to allow FINOS to act on behalf of the contributor for accounts related to the project (e.g., GitHub, domain names, social media) and to optionally manage trademark assignment.
-  - If the project name is new to FINOS and has not been used publicly by the contributor this agreement is not necessary.
-  - If the name is not new and has been used publicly in the past the contribution agreement must be signed even if no trademarks have been filled due to Common Law Trademark Rights.
-  - The above applies to any logos as well
-- [ ] Review contribution checklist with FINOS staff
-- [ ] Review FINOS project blueprint
-
-# 4.  FINOS Onboarding
+## 4.  Transfer and onboarding in FINOS
 
 This is performed by FINOS Infra once the three previous stages are complete, with support from the contributor and the FINOS Infra team.
 
 ## Code transfer preparation
-- [ ] Ensure [finos-admin](http://github.com/finos-admin) is Admin of the GitHub repository to transfer
+- [ ] Maintainer has made [finos-admin](http://github.com/finos-admin) Admin of the GitHub repository to transfer
 
 ## Code Transfer Meeting
 - [ ] Transfer all code assets as GitHub repositories under github.com/finos
@@ -158,4 +167,7 @@ This is performed by FINOS Infra once the three previous stages are complete, wi
 - [ ] (best effort) Update release coordinates and code namespace to include `finos`
 
 # 5. Announcement 
-- [ ] Lead maintainer works with FINOS marketing to send out announcement to announce@finos.org , checkout announcement template at the [Contribution page](https://community.finos.org/docs/governance/Software-Projects/contribution#step-5-contribution-announcements)
+- [ ] Issue assigned to FINOS DevRel team
+- [ ] Mantainer team agreed with FINOS DevRel team on announcements sequencing: `add link to internal task`
+- [ ] Technical announcement was sent to announce@finos.org (see [template](https://community.finos.org/docs/governance/Software-Projects/contribution#step-5-contribution-announcements): `add link to announce@ archive` 
+- [ ] If applicable, project was announced on FINOS marketing channels: `add link to FINOS social / press release`

--- a/.github/ISSUE_TEMPLATE/Special-Interest-Group-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Special-Interest-Group-Contribution.md
@@ -1,106 +1,157 @@
 ---
 name: "\U0001F58ASpecial Interest Group Contribution and Onboarding"
 about: To Contribute a Special Interest Group to FINOS
-title: Special Interest Group Contribution and Onboarding
+title: "[Insert name here] Special Interest Group Contribution and Onboarding"
 labels: contribution
 assignees: maoo, TheJuanAndOnly99
+---
+
+--- 
+# Prerequisites
+
+## Membership requirement to contribute new projects
+Please note that only FINOS members can propose new Special Interest Groups. If you're interested in membership, see [here](https://www.finos.org/membership-benefits#become-a-member). You can still submit this contribution if your organization is not a [FINOS member](https://finos.org/members), but you will be required to have a maintainer from a FINOS member.
+
+- [ ] I confirm I am contributing on behalf of a FINOS member (`add FINOS member organization name`) or I will seek a maintainer from a FINOS member during socialization 
+
+## Understading the contribution Process
+Completing an onboarding of a special interest group into FINOS comprises following 5 main steps described in details in our [Community Repository](https://community.finos.org/docs/governance/Software-Projects/contribution#contribution-of-an-existing-code-base-into-finos-as-a-new-project). 
+
+ - [ ] I confirm I have reviewed the contribution process.
+
+## Understanding FINOS
+
+As a SIG onboarding into FINOS, you should familiarize yourself and your contributor team with the following FINOS information: [FINOS overview](https://www.finos.org/hubfs/An%20Introduction%20to%20FINOS.pdf), [FINOS SIG Governance](/docs/governance/#special-interest-groups)), [FINOS Maintainers cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet/).
+
+- [ ] I confirm I am familiar with the FINOS governance and maintainers (Chair) responsibilities
 
 ---
-Please note that only FINOS members can propose new projects. If you're interested in membership, see https://www.finos.org/membership-benefits#become-a-member.
+# SIG information
 
-## Business Problem
-*Describe the business problem the contribution solves*
+## Describing The Contribution
+
+This section contains information to be provided by the contributor to give it the best chances to be approve stage. A SIG is a great place to have conversation around a certain area of interest, generally in the "problem space" to then proceed to create or contribute a software or standard project to provide a solition. Please review a list of [existing SIGs](https://community.finos.org/docs/governance/special-interest-groups/) before proposing one as you might find your area of interest already covered. 
+
+Please fill below as appropriate:
+
+### Proposed SIG Metadata
+- Name: `enter here proposed project name`
+- Slug: `enter here proposed project description`
+
+> Please review the [trademark checks](docs/governance/Software-Projects/contribution#trademark) that will be performed on the projects.
+
+### Describe the Need
+> Describe why you are proposing the creation of a SIG and why the topic cannot be covered in any of the [existing SIGs](https://community.finos.org/docs/governance/special-interest-groups/).
+
+### Proposed SIG charter
+*Describe the mission and goals of the SIG*
  
-## Proposed Solution
-*Describe the type of contribution and how it solves that business problem*
- 
-## Current State
+### Current State
 *Summarize the history and current state of the special interest group*
  
-## Existing Materials
+### Existing Materials
 *If materials already exist, provide a link to them that Foundation staff can access - if it's in a private GitHub.com repositories, you should invite the finos-admin user with R/O permissions to those repositories*
 
-## SIG Maintainers
-*Who will be the [SIG maintainer(s)](https://community.finos.org/docs/finos-maintainers-cheatsheet/#maintainer-responsibilities-and-available-resources)? Provide full name, affiliation, work email address, and GitHub.com username.*
+## SIG Team
 
-# SIG Contribution and Onboarding process (v. 1.0, last updated on October 27, 2020)
-Below is the list of tasks that FINOS Team and the contribution author goes through in order to complete the FINOS SIG onboarding process. **Please do not edit these contents at contribution time!**
+### SIG Chair and Vice Chair 
+*Who will be the Chair and Vice chair who responsible for setting and driving as well as engaging with the community akin to a project [maintainer's responsibilities](https://community.finos.org/docs/finos-maintainers-cheatsheet/#maintainer-responsibilities-and-available-resources)? Provide full name, affiliation, GitHub / GitLab username and email address where available*
 
-## Voting (SIG Lead and FINOS ED)
-- [ ] Contribution author triggers community socialization to gauge interest - recommended emailing issue link to community@finos.org
-- [ ] If there's positive response from the Community, prepare short SIG proposal deck for the FINOS Governing Board. You can start from [this template](/governance-docs/202103-New-Project-or-SIG-proposal-(template)-PUBLIC.pptx) or see a [previous SIG example](https://community.finos.org/assets/files/202101-InnerSource-SIG-Proposal-APPROVED-85e2fa26d6d2589ea59eb4ff6ab31e67.pdf)
-- [ ] Assign issue to Executive Director (@mindthegab) to trigger vote
-- [ ] Executive Director brings SIG to the Board for additional socialization and approval
-- [ ] FINOS board accepts the SIG (and the onboarding process can move forward)
+|Name                        |Affiliation              | Email Address             |Github / GitLab username              |
+|----------------------------|-------------------------|-------------------------------|--------------------------------------|
+|John Example (Chair)               |Example LTD              |john@example.com               |@johnexampleabc                       |
+|Jane Example (Vice-Chair)                |Example LTD              |jane@example.com               |@janeexamplexyz                       |
 
-## Identify project meta (Lead: FINOS SIG POC, Support: FINOS Marketing)
-- [ ] Identify and Assign FINOS SIG POC
-- [ ] Link to SIG approval resolution - // _public link to board resolution_
-- [ ] SIG Name
-    - [ ] Assess current trademark status
-    - [ ] Define new SIG name (if applicable)
-    - [ ] Design new SIG logo (if applicable)
-    - [ ] Trademark new SIG name and logo (if applicable)
-- [ ] Category and sub-category (for FINOS Landscape)
-- [ ] Existing content/assets or new Github repository
-- [ ] Team composition: lead maintainer and other maintainers
-- [ ] Meetings? (existing/yes/no)
-- [ ] Meeting minutes, agenda, attendance tracking (existing/yes/no)
-- [ ] Documentation website (existing/yes/no)
-- [ ] Define SIG slug : Dependant on `Define new SIG name`
+### Confirmed SIG participants
+*If applicable, list all of the individuals that have expressed interest in and/or are committed to contributing to this project, including full name, affiliation, work email address, and GitHub.com username*
 
-## Project Communication Channel(s)
-- [ ] Ask maintainers which communications channels they'd like to use and if more than one are needed. These may include
-    - [ ] Creation of one or more project mailing lists (e.g. general@, or dev@ and users@)
-    - [ ] Creation of one or more Slack or Symphony chats for the project
-- [ ] Create the identified communication channels during infra set up
-- [ ] Link communication channels linked front and center in the project README.md.
+|Name                        |Affiliation              |Work Email Address             |Github / GitLab username              |
+|----------------------------|-------------------------|-------------------------------|--------------------------------------|
+|Contributor1 Example        |Example LTD              |con1@example.com               |@con1xampleabc                        |
+|Contributor2 Example        |Example LTD              |con2@example.com               |@con2examplexyz                       |
 
-## Repository transfer (Lead: FINOS Infra)
-- [ ] Check GitHub repository transfer requirements:
-  - [ ] [finos-admin](http://github.com/finos-admin) has `Admin` to all repositories to transfer
-  - [ ] [finos-admin](http://github.com/finos-admin) is allowed to transfer repositories out of the org
-  - [ ] if the repository is owned by a user (and not an org), the user must be able to transfer the repository to [finos-admin](http://github.com/finos-admin)
+### Target Participants
+*Describe the participant profile (background, position, etc) and if applicable organizational profile (financial institutions, tech vendors, consulting firms, etc) you would like to get contributions from*
+
+## Preferred SIG infrastructure
+If the SIG is approved, FINOS will provision the infrastructure necessary for [collaboration](https://community.finos.org/docs/collaboration-infrastructure). Below a list of questions which will help us accelerate the onboarding process and tailor it to the maintainers needs:
+
+- Which hosting platform does the project prefer? *[Github](https://github.com/finos/)|[GitLab](https://gitlab.com/finos)* 
+- Please check below which asynchronous collaboration channels will the project like to use?
+  - [ ] GitHub Issues
+  - [ ] GitHub Public Discussions
+  - [ ] GitHub Team Discussions _(consisting of the above described contributors)_
+    - Public (Mandatory) _(consisting of the above described contributors)_
+    - [ ] Private (Optional)
+  - [ ] Mailing-list (lists.finos.org)
+    - General (Mandatory, for project community): `add preferred address, XXXX-general@lists.finos.org`
+    - [ ] Private (Optional)
+  - [ ] FINOS Slack Channel _(consisting of the above described contributors)_
+    - General Project Community Public channel (mandatory): `add preferred channel name, e.g. #projectName-general`
+    - [ ] Chairs Private Channel (Optional) `add preferred channel name, e.g. #projectName-chairs`
+- Synchronous
+  - [ ] Will the project host recurring meetings complying with the [FINOS meeting procedures](https://community.finos.org/docs/governance/meeting-procedures)?
+
+---
+# Next steps and what to expect 
+
+## 1. Socialisation 
+It's highly recommended that once you submit this issue, you or anyone in the maintainer team proceed with socializing directly to the [FINOS community](mailto:community@finos.org) and through your personal network. The goal is to generate interest, support and ideally additional committed participant expressing the interest on the issue before it's sent to the Governing Board for approval. 
+
+Instructions and a template for you to adjust are avaialble in the [Contribution Process Socialization](https://community.finos.org/docs/governance/software-projects/contribution/#step-2-socialization) documentation.
+
+- [ ] I confirm I have socialized this contribution to `community@finos.org` (to be checked after the issue is raised)
+
+# 2. Approval
+The [FINOS Governing Board]([https://github.com/finos/technical-oversight-committee](https://www.finos.org/governing-board)) is responsible for approving new FINOS standards.
+
+Once you are happy with the socialization phase (garnered enough support / interest, addressed open questions, etc), please prepare a short slide deck (10m), check the box below, and put a comment on this issue so the proposal can be sent to the Governing Board for approval via email or at the next Governing Board meeting 
+
+- [ ] I am happy for this issue to be sent to the Governing Board for formal review and approval and I prepared a short SIG proposal deck for the FINOS Governing Board `replace [this template](/governance-docs/202103-New-Project-or-SIG-proposal-(template)-PUBLIC.pptx) with link or attach to the issue` 
+- [ ] FINOS team notified leadership@finos.org to trigger Governing Board approval and assigned this issue to COO
+- [ ] FINOS Leadership confirmed timing and procedure of Governing Board vote with contributors
+
+### Governing Board Approval findings 
+- [ ] FINOS Governing Board reviewed the contribution and the contribution was: `accepted|rejected`
+
+> FINOS team to enter high level findings summary here supporting the decision
+
+## 3. Preparing For Onboarding
+Before the FINOS team can onboard your project, there are a few housekeeping items that need to be taken care of from an IP and infastructure standpoint. These must be completed by the contributor, with help if required from the FINOS Infrastructure team, so please familiarize yourself with the [requirements](/docs/governance/software-projects/contribution/#step-4-ip-review--transfer-of-contributions).
+
+### Steps
+- [ ] Usable name and logo identified (either existing or new)
+  - [ ] FINOS team confirmed project brand and logo are usable in the public domain. This might require completion of [project contribution agreement](https://community.finos.org/governance-docs/The.Linux.Foundation.--.Form.of.Trademark.Assignment.20221202.pdf) to properly assign trademarks.
+  - [ ] Failed the above, new project name and logo is identified
+- [ ] FINOS team enabled documentation DCO (developer certificate of origin) to enforce CC-by-40 license, [default for SIGs](/docs/governance#special-interest-groups)
+- [ ] FINOS team was given admin access to any existing project account (e.g. GitHub, domain names, social media) to be able to act on behalf of the contributor for accounts related to the project 
+- [ ] Kick-off meeting organized by FINOS team, including:
+   - [ ] Review contribution checklist with FINOS staff
+   - [ ] Contributor confirms having reviewed and agreed to [FINOS SIG governance](/docs/governance#special-interest-groups) and [FINOS meeting procedures](/docs/governance/meeting-procedures)
+   - [ ] FINOS agrees with Chairs on category and sub-category (for [FINOS Landscape](https://landscape.finos.org/) placement
+   groups)
+
+## 4.  Transfer and onboarding in FINOS
+This is performed by FINOS Infra once the three previous stages are complete, with support from the contributor and the FINOS Infra team.
+
+## Code transfer preparation
+- [ ] Maintainer has made [finos-admin](http://github.com/finos-admin) Admin of the GitHub repository to transfer
+
+## Existing assets transfer Meeting
 - [ ] Transfer all assets as GitHub repositories under github.com/finos
-- [ ] Invite GitHub usernames to GitHub FINOS Org
-- [ ] Create `<sig-name>-maintainers` GitHub team and invite users
-- [ ] Configure `finos-admins` and `finos-staff` team permissions
+- [ ] Rename main branch to `main` (instead of `master`)
+- [ ] Check that CVE (and preferably static code analysis, if applicable) scanning is in place
+- [ ] Enable [branch protection](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) (`Require a pull request before merging`)
+- [ ] Enable automated dependency update, using [Renovate](https://renovatebot.com/)
+- [ ] (best effort or to be completed right after onboarding) Update release coordinates and code namespace to include `finos`
+- [ ] Communication channels are linked front and center in the project README.md
+- [ ] Communication channels are linked front and center in the project README.md
+- [ ] SIG badge is updated
+- [ ] SIG is listed in [FINOS SIGs listing page](/docs/governance/special-interest-
 
-## Infra setup (Lead: FINOS Infra)
-- [ ] Update SIG badge
-- [ ] Update SIG README
-- [ ] Enable meeting attendance tracking (optional)
-
-## Metadata update (Lead: FINOS Infra)
-- [ ] Add SIG to metadata
-- [ ] Add identities, orgs and affiliations to metadata
-- [ ] Add logo to FINOS landscape
-- [ ] Add SIG Leads emails to finos-project-maintainers@finos.org list
-- [ ] Add SIG Leads GitHub usernames to the project-maintainers Team
-
-## Update FINOS SIG Roster
-- [ ] [FINOS Governance](https://community.finos.org/docs/governance/special-interest-groups)
-
-## Announcement (Lead: FINOS POC)
-- [ ] Work with FINOS marketing to send out announcement to announce@finos.org , checkout announcement template at the [Contribution page](https://community.finos.org/docs/governance/Software-Projects/contribution).
-- [ ] Notify FINOS POC and FINOS marketing manager once the announcement has been sent out (FINOS infra)
-
-## Press Release (OPTIONAL) (Lead: FINOS POC)
-- [ ] Identify quotes for press release
-- [ ] Draft press release
-- [ ] Send embargoed press release to reporters
-- [ ] Coordinate social media promotion of the press release with FINOS marketing 
-    - [ ] Post on FINOS social media
-    - [ ] Post on LF social media
-
-## Onboarding and training
-- [ ] FINOS SIG Governance
-- [ ] FINOS Project Lifecycle
-- [ ] FINOS Collaboration infrastructure
-
-## Contributors Metadata (Lead: FINOS SIG POC, Support: FINOS infra)
-- [ ] For each SIG material contributor identified in the previous step, collect: the following info:
-  - Fullname
-  - GitHub username
-  - Corporate email address
-- [ ] Identify other existing contributors (assuming there's a contribution history (eg Git history)
+--- 
+# Announcement 
+- [ ] Issue assigned to FINOS DevRel team
+- [ ] Mantainer team agreed with FINOS DevRel team on announcements sequencing: `add link to internal task`
+  - [ ] Technical announcement was sent to announce@finos.org (see [template](https://community.finos.org/docs/governance/Software-Projects/contribution#step-5-contribution-announcements): `add link to announce@ archive` 
+  - [ ] If applicable, SIG was announced on FINOS marketing channels: `add link to FINOS social / press release`

--- a/.github/ISSUE_TEMPLATE/Standards-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Standards-Project-Contribution.md
@@ -183,7 +183,8 @@ This is performed by FINOS Infra once the three previous stages are complete, wi
 - [ ] (best effort or to be completed right after onboarding) Update release coordinates and code namespace to include `finos`
 - [ ] Communication channels are linked front and center in the project README.md
 
-# 5. Announcement 
+---
+# Announcement 
 - [ ] Issue assigned to FINOS DevRel team
 - [ ] Mantainer team agreed with FINOS DevRel team on announcements sequencing: `add link to internal task`
   - [ ] Technical announcement was sent to announce@finos.org (see [template](https://community.finos.org/docs/governance/Software-Projects/contribution#step-5-contribution-announcements): `add link to announce@ archive` 

--- a/.github/ISSUE_TEMPLATE/Standards-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Standards-Project-Contribution.md
@@ -1,155 +1,187 @@
 ---
 name: "\U0001F58AStandard Project Contribution and Onboarding"
 about: To Contribute a Standard Project to FINOS
-title: Standard Project Contribution and Onboarding
+title: "[insert name here] Standard Project Contribution and Onboarding"
 labels: contribution
 assignees: maoo, TheJuanAndOnly99
+---
 
 ---
-Please note that only FINOS members can propose new projects. If you're interested in membership, see https://www.finos.org/membership-benefits#become-a-member.
+# Prerequisites
 
-# Onboarding Process
+## Membership requirement to contribute new projects
 
-Completing an onboarding of a project into FINOS requires following these 5 main steps:  
+Please note that only FINOS members can propose new projects. If you're interested in membership, see [here](https://www.finos.org/membership-benefits#become-a-member). You can still submit this contribution if your organization is not a [FINOS member](https://finos.org/members), but you will be required to have a maintainer from a FINOS member.
 
-1.  [**Describing the Contribution**](#1-describing-the-contribution) _led by contributor_
-2.  [**Approval**](#2-approval) _led by FINOS TOC_
-3.  [**Preparing for Onboarding**](#3-preparing-for-onboarding) _led by contributor_
-4.  [**Onboarding**](#4--finos-onboarding) _completed by FINOS Infra_
-5.  [**Announcement**](#4--finos-onboarding) _led by FINOS Marketing_
+- [ ] I confirm I am contributing on behalf of a FINOS member (`add FINOS member organization name`) or I will seek a maintainer from a FINOS member during socialization 
 
-# 1. Describing The Contribution
+## Understading the contribution Process
 
-This is a list of questions that need to be answered by the contributor in order to allow a new project to pass to the approval stage of onboarding.
+Completing an onboarding of a project into FINOS comprises following 5 main steps described in details in our [Community Repository](https://community.finos.org/docs/governance/Software-Projects/contribution#contribution-of-an-existing-code-base-into-finos-as-a-new-project). 
 
-## Business Problem
-*Describe the business problem or opportunity the proposed standard addresses*
+ - [ ] I confirm I have reviewed the contribution process.
+
+## Understanding FINOS
+
+As a project onboarding into FINOS, you should familiarize yourself and your contributor team with the following FINOS information: [FINOS overview](https://www.finos.org/hubfs/An%20Introduction%20to%20FINOS.pdf), [FINOS Standard Projects Governance](/docs/governance/#open-standard-projects), [FINOS Project Lifecycle](/docs/governance/Software-Projects/project-lifecycle), [FINOS Maintainers cheatsheet](/docs/finos-maintainers-cheatsheet/).
+
+- [ ] I confirm I am familiar with the FINOS Standards governance and maintainers responsibilities
+
+---
+# Contribution information
+
+## Describing The Contribution
+
+This section contains information to be provided by the original to give it the best chances to be approve stage. They largely mirror the requirements described in the [incubation checklist](/docs/governance/software-projects/stages/incubating/#incubating-lifecycle-checklist). Please fill below as appropriate:
+
+### Proposed Project Metadata
+- Name: `enter here proposed standard name`
+- Slug: `enter here proposed standard short description`
+  
+> Please review the [trademark checks](docs/governance/Software-Projects/contribution#trademark) that will be performed on the projects.
+
+### Business Problem
+> Describe the business or technical problem the standard solves and for whom
  
-## Proposed Solution
-*Describe the proposed standard, including the format if known (e.g. specification, model, extension to existing standard) and how it solves that business problem*
+### Proposed Solution
+> Describe how this standard project solves that business problem
 
-## Tentative Roadmap
-*Describe the short and medium term goals and phases of the project. What does success look like for this project?* 
+### Tentative Roadmap
+> Describe the short and medium term goals and phases of the project. What does success look like for this project?
 
-## Scope
-*Clearly define the scope of the standard. In cases where the scope is expected to be defined by the standard project participants this should be one of the first tasks the group completes. Guidelines can be found in the [Community Specification documentation](https://github.com/finos/standards-project-blueprint).*
+### Scope
+> Clearly define the scope of the standard to define the patent license boundaries. In cases where the scope is expected to be defined by the standard project participants this should be one of the first tasks the group completes. Guidelines can be found in the [Community Specification Best Practices #3]([https://github.com/finos/standards-project-blueprint](https://github.com/finos/standards-project-blueprint/blob/main/governance-documents/Getting%20Started.md#best-practices))
 
-## Current State
+### Current State
 *Summarize the history and current state of the project*
  
-## Existing Materials
-*If materials already exist, provide a link to them that Foundation staff can access - if it's in a private GitHub.com repository, you should invite the finos-admin user with R/O permissions to those repositories*
+### Identify existing project resources and materials
+ - [ ] Does the project have a public Source Repository?
+   - If so, what's the URL for the repository: `replace if it exists or add N/A`
+   - [ ] If code is private, was @finos-admin already given read-only permissions to the repo or a code provided to the team?
+ - [ ] Is Continuous Integration used?
+   - If so, which CI/CD system is used: `enter here`
+ - [ ] Was the project ever had public releases? 
+   - If so, where's the latest released version: `add link here`
+ - [ ] Does the project build work successfully?
+   - If so, please add link to build instructions: `add link to build instructions`
+ - [ ] Does the project have existing documentation?
+   - If so, provide more information: `add site URL / PDF / etc here`
+ - [ ] Does the project have a registered trademark or the name has been prevously used in the public domain?
+   - If so, add link to previously used public links : `link to press release / repository / blog`
+ - [ ] Is there an existing logo?
+   - If so, please add link or attach to the issue: `link to high res logo or added as attachment`
+ - [ ] Is there a high-level pitch deck to be evaluated by Technical Oversight Committee?
+   - If so, please add link or attach to the issue: `link to a ~15 mins slide deck or added as attachment`
+ - [ ] Are meetings currently held for the project?
+   - If so, please add link to current meeting schedule / minutes: `link to meeting details`
+ - [ ] Is it a data model?
+   - [ ] If so, are you interested in modeling it in the [FINOS Legend Studio Sandbox](https://www.finos.org/legend)?
 
- ## Identify project meta
-- [ ] Project Name
-    - [ ] Standard Name
-    - [ ] Assess current trademark status
-    - [ ] Define new project name (if applicable)
-    - [ ] Design new project logo (if applicable)
-    - [ ] Trademark new project name and logo (if applicable)
-- [ ] Category and sub-category (for FINOS Landscape)
-- [ ] Existing code or new Github repository
-- [ ] Existing code releases (and which artifact repositories are used)
-- [ ] Team composition: lead maintainer and other maintainers
-- [ ] Meetings (existing/yes/no)
-- [ ] Meeting minutes, agenda, attendance tracking (existing/yes/no)
-- [ ] Continuous Integration (existing/yes/no)
-- [ ] Documentation website (existing/yes/no)
-- [ ] Define project slug
-
-## Development Team
+## Standard Project Team
+FINOS uses the [Community Specification License](https://github.com/finos/standards-project-blueprint/blob/main/governance-documents/1._Community_Specification_License-v1.md) for its standards, which clearly defines [three key roles](https://github.com/finos/standards-project-blueprint/blob/main/governance-documents/5._Governance.md#1roles) to develop a specification. Please provide as much information as possible on who will fulfill these roles: 
 
 ### Maintainers
-*Who will be the [project maintainer(s)](https://community.finos.org/docs/finos-maintainers-cheatsheet/#maintainer-responsibilities-and-available-resources)? Provide full name, affiliation, work email address, and GitHub / GitLab username.*
+*Maintainers are responsible for organizing activities around developing, maintaining, and updating the specification(s). Provide full name, affiliation, GitHub / GitLab username and email address where available:*
 
 |Name                        |Affiliation              |Work Email Address             |Github / GitLab username              |
 |----------------------------|-------------------------|-------------------------------|--------------------------------------|
 |John Example                |Example LTD              |john@example.com               |@johnexampleabc                       |
 |Jane Example                |Example LTD              |jane@example.com               |@janeexamplexyz                       |
 
+### Editors
+*Editors are responsible for ensuring that the contents of the document accurately reflect the decisions that have been made by the group, and that the specification adheres to formatting and content guidelines. Provide full name, affiliation, GitHub / GitLab username and email address where available:*
 
-### Confirmed contributors
-*If applicable, list all of the individuals that have expressed interest in and/or are committed to contributing to this project, including full name, affiliation, work email address, and GitHub.com username*
+|Name                        |Affiliation              |Work Email Address             |Github / GitLab username              |
+|----------------------------|-------------------------|-------------------------------|--------------------------------------|
+|John Example                |Example LTD              |john@example.com               |@johnexampleabc                       |
+|Jane Example                |Example LTD              |jane@example.com               |@janeexamplexyz                       |
+
+### Confirmed Participants
+*Participants are those who are expected to made Contributions by joining project meetings and via pull requests. Please list all of the individuals that have expressed interest in and/or are committed to contributing to this project, including full name, affiliation, GitHub  / GitLab username and email address where available:*
 
 |Name                        |Affiliation              |Work Email Address             |Github / GitLab username              |
 |----------------------------|-------------------------|-------------------------------|--------------------------------------|
 |Contributor1 Example        |Example LTD              |con1@example.com               |@con1xampleabc                        |
 |Contributor2 Example        |Example LTD              |con2@example.com               |@con2examplexyz                       |
 
-
 ### Target Contributors
-*Describe the contributor profile (background, position, organization) you would like to get contributions from.*
+*Describe the contributor profile (background, position, etc) and if applicable organizational profile (financial institutions, tech vendors, consulting firms, etc) you would like to get contributions from*
 
-## Project Communication Channel(s)
+## Preferred project infrastructure
+If the project is approved, FINOS will provision the infrastructure necessary for [development, release and project collaboration](https://community.finos.org/docs/collaboration-infrastructure). Below a list of questions which will help us accelerate the onboarding process and tailor it to the maintainers needs:
 
-- [ ] Contributor to ask maintainers which communications channels they'd like to use:
-- Asynchronous
-  - [ ] GitHub Issues _(public)_
-  - [ ] GitHub Discussions _(public)_
+- Which code hosting platform does the project prefer? *[Github](https://github.com/finos/)|[GitLab](https://gitlab.com/finos)* 
+- Please check below which asynchronous collaboration channels will the project like to use?
+  - [ ] GitHub Issues
+  - [ ] GitHub Public Discussions
   - [ ] GitHub Team Discussions _(consisting of the above described contributors)_
-    - [ ] Public
-    - [ ] Private
-  - [ ] Mailing-list (groups.io)
-  - [ ] FINOS Slack Channel (consisting of the above described contributors)
-    - [ ] General (public) _(supply channel name)_ 
-    - [ ] Leadership (private) _(supply channel name)_
+    - Public (Mandatory) _(consisting of the above described contributors)_
+    - [ ] Private (Optional)
+  - [ ] Mailing-list (lists.finos.org)
+    - General (Mandatory, for project community): `add preferred address, XXXX-general@lists.finos.org`
+    - [ ] Private (Optional)
+  - [ ] FINOS Slack Channel _(consisting of the above described contributors)_
+    - General Project Community Public channel (mandatory): `add preferred channel name, e.g. #projectName-general`
+    - [ ] Maintainers Private Channel (Optional) `add preferred channel name, e.g. #projectName-maintainers`
 - Synchronous
-  - [ ] Recurring meetings
+  - [ ] Will the project host recurring meetings complying with the [FINOS meeting procedures](https://community.finos.org/docs/governance/meeting-procedures)?
 
-## Understanding FINOS Onboarding Requirements
+---
+# Next steps and what to expect 
 
-As a project onboarding into FINOS, you will need to familiarize yourself and your contributor team with the following materials:
+## 1. Socialisation 
+It's highly recommended that once you submit this issue, you or anyone in the maintainer team proceed with socializing directly to the [FINOS community](mailto:community@finos.org) and through your personal network. The goal is to generate interest, support and ideally additional committed maintainers expressing the interest on the issue before it's sent to the Technical Oversight Committee for approval. 
 
- - [FINOS overview](https://www.finos.org/hubfs/An%20Introduction%20to%20FINOS.pdf) (if necessary)
- - [FINOS Maintainers cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet/)
- - [FINOS Project/Standards Governance](https://community.finos.org/docs/governance)
- - [FINOS Project Lifecycle](https://community.finos.org/docs/governance/Software-Projects/project-lifecycle)
+Instructions and a template for you to adjust are avaialble in the [Contribution Process Socialization](https://community.finos.org/docs/governance/software-projects/contribution/#step-2-socialization) documentation.
 
-## Socialisation 
-- [ ] Write and send contribution proposal announcement (optional - see below)
-- [ ] Lead maintainer to send out announcement to community@finos.org using this template:
+- [ ] I confirm I have socialized this contribution to `community@finos.org` (to be checked after the issue is raised)
     
-    ```
-    Dear FINOS Community, 
-    
-    We would like to propose a new FINOS project. Please review the proposal details at (_TODO: add link to the GitHub issue proposal_).
-    
-    If you're interested in participating, please :+1: the GitHub issue proposal and drop a comment with your name, org and email
+## 2. Approval
+The [FINOS Governing Board]([https://github.com/finos/technical-oversight-committee](https://www.finos.org/governing-board)) is responsible for approving FINOS project contributions.
 
-   Thanks a lot,
-   ```     
+Once you are happy with the socialization phase (garnered enough support / interest, addressed open questions, etc), please check the box below and put a comment on this issue so it can be sent to the Governing Board for approval via email or at the next Governing Board meeting . 
 
-# 2. Approval
-- [ ] Assign issue to Executive Director (@mindthegab) to trigger voting. If additional socialization is required, the Executive Director may bring standards projects to the FINOS Governing Board
-- [ ] FINOS Governing Board accepts the contribution/new standard project (and the contribution process can move forward)
+- [ ] I am happy for this issue to be sent to the Governing Board for formal review and approval
+- [ ] FINOS team notified leadership@finos.org to trigger Governing Board approval and assigned this issue to COO
+- [ ] FINOS Leadership confirmed timing and procedure of Governing Board vote
 
-# 3. Preparing For Onboarding
+### Governing Board Approval findings 
+- [ ] FINOS Governing Board reviewed the contribution and the contribution was: `accepted|rejected`
 
-Before the FINOS team can onboard your project, there are a few housekeeping items that need to be taken care of.  These must be completed by the contributor, with help if required from the FINOS Infra.   
+> FINOS team to enter high level findings summary here supporting the decision
 
-## Kick-off meeting
-- [ ] Review the [project contribution agreement](https://community.finos.org/governance-docs/The.Linux.Foundation.--.Form.of.Trademark.Assignment.20221202.pdf) to allow FINOS to act on behalf of the contributor for accounts related to the project (e.g., GitHub, domain names, social media) and to optionally manage trademark assignment.
-  - If the project name is new to FINOS and has not been used publicly by the contributor this agreement is not necessary.
-  - If the name is not new and has been used publicly in the past the contribution agreement must be signed even if no trademarks have been filled due to Common Law Trademark Rights.
-  - The above applies to any logos as well
-- [ ] Review contribution checklist with FINOS staff
-- [ ] Review FINOS project blueprint
+## 3. Preparing For Onboarding
+Before the FINOS team can onboard your project, there are a few housekeeping items that need to be taken care of from an IP and infastructure standpoint. These must be completed by the contributor, with help if required from the FINOS Infrastructure team, so please familiarize yourself with the [requirements](/docs/governance/software-projects/contribution/#step-4-ip-review--transfer-of-contributions).
 
-# 4.  FINOS Onboarding
+### Steps
+- [ ] Usable name and logo identified (either existing or new)
+  - [ ] FINOS team confirmed project brand and logo are usable in the public domain. This might require completion of [project contribution agreement](https://community.finos.org/governance-docs/The.Linux.Foundation.--.Form.of.Trademark.Assignment.20221202.pdf) to properly assign trademarks.
+  - [ ] Failed the above, new project name and logo is being identified
+- [ ] FINOS team enables [EasyCLA](https://easycla.lfx.linuxfoundation.org/#/) with Community Specification License
+- [ ] FINOS contributor license agreement is reviewed and executed by all maintainers
+- [ ] FINOS team was given admin access to any existing project account (e.g. GitHub, domain names, social media) to be able to act on behalf of the contributor for accounts related to the project  
+- [ ] Kick-off meeting organized by FINOS team, including:
+   - [ ] Review contribution checklist with FINOS staff
+   - [ ] Contributor confirms having reviewed [FINOS standard project procedures](/docs/governance/Standards-Projects)) and agreed to adopt governance
+   - [ ] FINOS agrees with maintainers on category and sub-category (for [FINOS Landscape](https://landscape.finos.org/))
 
+## 4.  Transfer and onboarding in FINOS
 This is performed by FINOS Infra once the three previous stages are complete, with support from the contributor and the FINOS Infra team.
 
 ## Code transfer preparation
-- [ ] Ensure [finos-admin](http://github.com/finos-admin) is Admin of the GitHub repository to transfer
+- [ ] Maintainer has made [finos-admin](http://github.com/finos-admin) Admin of the GitHub repository to transfer
 
-## Code Transfer Meeting
-- [ ] Transfer all code assets as GitHub repositories under github.com/finos
+## Existing assets transfer Meeting
+- [ ] Transfer all  assets as GitHub repositories under github.com/finos
 - [ ] Rename main branch to `main` (instead of `master`)
-- [ ] Enable EasyCLA
 - [ ] Check that CVE (and preferably static code analysis, if applicable) scanning is in place
 - [ ] Enable [branch protection](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) (`Require a pull request before merging`)
 - [ ] Enable automated dependency update, using [Renovate](https://renovatebot.com/)
-- [ ] (best effort) Update release coordinates and code namespace to include `finos`
+- [ ] (best effort or to be completed right after onboarding) Update release coordinates and code namespace to include `finos`
 
 # 5. Announcement 
-- [ ] Lead maintainer works with FINOS marketing to send out announcement to announce@finos.org , checkout announcement template at the [Contribution page](https://community.finos.org/docs/governance/Software-Projects/contribution#step-5-contribution-announcements)
+- [ ] Issue assigned to FINOS DevRel team
+- [ ] Mantainer team agreed with FINOS DevRel team on announcements sequencing: `add link to internal task`
+  - [ ] Technical announcement was sent to announce@finos.org (see [template](https://community.finos.org/docs/governance/Software-Projects/contribution#step-5-contribution-announcements): `add link to announce@ archive` 
+  - [ ] If applicable, project was announced on FINOS marketing channels: `add link to FINOS social / press release`

--- a/.github/ISSUE_TEMPLATE/Standards-Project-Contribution.md
+++ b/.github/ISSUE_TEMPLATE/Standards-Project-Contribution.md
@@ -138,13 +138,13 @@ Instructions and a template for you to adjust are avaialble in the [Contribution
 - [ ] I confirm I have socialized this contribution to `community@finos.org` (to be checked after the issue is raised)
     
 ## 2. Approval
-The [FINOS Governing Board]([https://github.com/finos/technical-oversight-committee](https://www.finos.org/governing-board)) is responsible for approving FINOS project contributions.
+The [FINOS Governing Board]([https://github.com/finos/technical-oversight-committee](https://www.finos.org/governing-board)) is responsible for approving new FINOS standards.
 
 Once you are happy with the socialization phase (garnered enough support / interest, addressed open questions, etc), please check the box below and put a comment on this issue so it can be sent to the Governing Board for approval via email or at the next Governing Board meeting . 
 
 - [ ] I am happy for this issue to be sent to the Governing Board for formal review and approval
-- [ ] FINOS team notified leadership@finos.org to trigger Governing Board approval and assigned this issue to COO
-- [ ] FINOS Leadership confirmed timing and procedure of Governing Board vote
+- [ ] FINOS Infra team notifies leadership@finos.org to trigger Governing Board approval and assigned this issue to COO
+- [ ] FINOS Leadership confirmed timing and procedure of Governing Board vote with contributors 
 
 ### Governing Board Approval findings 
 - [ ] FINOS Governing Board reviewed the contribution and the contribution was: `accepted|rejected`
@@ -157,7 +157,7 @@ Before the FINOS team can onboard your project, there are a few housekeeping ite
 ### Steps
 - [ ] Usable name and logo identified (either existing or new)
   - [ ] FINOS team confirmed project brand and logo are usable in the public domain. This might require completion of [project contribution agreement](https://community.finos.org/governance-docs/The.Linux.Foundation.--.Form.of.Trademark.Assignment.20221202.pdf) to properly assign trademarks.
-  - [ ] Failed the above, new project name and logo is being identified
+  - [ ] Failed the above, new project name and logo is identified
 - [ ] FINOS team enables [EasyCLA](https://easycla.lfx.linuxfoundation.org/#/) with Community Specification License
 - [ ] FINOS contributor license agreement is reviewed and executed by all maintainers
 - [ ] FINOS team was given admin access to any existing project account (e.g. GitHub, domain names, social media) to be able to act on behalf of the contributor for accounts related to the project  
@@ -165,6 +165,8 @@ Before the FINOS team can onboard your project, there are a few housekeeping ite
    - [ ] Review contribution checklist with FINOS staff
    - [ ] Contributor confirms having reviewed [FINOS standard project procedures](/docs/governance/Standards-Projects)) and agreed to adopt governance
    - [ ] FINOS agrees with maintainers on category and sub-category (for [FINOS Landscape](https://landscape.finos.org/))
+   - [ ] Update Project badge
+
 
 ## 4.  Transfer and onboarding in FINOS
 This is performed by FINOS Infra once the three previous stages are complete, with support from the contributor and the FINOS Infra team.
@@ -179,6 +181,7 @@ This is performed by FINOS Infra once the three previous stages are complete, wi
 - [ ] Enable [branch protection](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) (`Require a pull request before merging`)
 - [ ] Enable automated dependency update, using [Renovate](https://renovatebot.com/)
 - [ ] (best effort or to be completed right after onboarding) Update release coordinates and code namespace to include `finos`
+- [ ] Communication channels are linked front and center in the project README.md
 
 # 5. Announcement 
 - [ ] Issue assigned to FINOS DevRel team


### PR DESCRIPTION
Hey @TheJuanAndOnly99 @maoo,

I built on your initial pass to revise the templates and reworked to include the following concepts:

1. Make the contributor specify upfront as much as possible information that will be required later in the process, both by infra and by approval stages)
2. Provide clear (and single sourced) pointers to community.finos.org (on IP, governance, etc), rather than duplicating information in templates to make sure it can be kept updated in only one place
3. Provide very clear checks for contributors to confirm they reviewed and agreed critical documentation
4. Update FINOS related checklist items to be "outcomes" that are relevant and important for the community to know and be informed about - the "how" it should be done can be tracked internally in our project management systems
5. Formalized the "announcement phase" with a handoff to DevRel, who can work with both contributors and marketing (both marketing ops and corporate marketing) to then finalize the announcement
6. Updated the SIG template accordingly.

Can you please check for completeness and if you are OK with the format? If so, you might want to update the internal companion Asana templates accordingly. 

As next steps: recommend you raise a final PR towards the community repo, and have Olivier, Grizz, Eddie as final approvers. 